### PR TITLE
refactor: add a middleware that ensures the database is awaken for each

### DIFF
--- a/app/Extensions/Extensions.cs
+++ b/app/Extensions/Extensions.cs
@@ -30,6 +30,7 @@ public static class Extensions
         }
 
         services.AddScoped<IUnitOfWork,UnitOfWork>();
+        services.AddScoped<DatabaseCheckMiddleware>();
         services.AddScoped<IEventService,EventService>();
         services.AddScoped<IPartnerService,PartnerService>();
         services.AddScoped<IIdentityService,IdentityService>();

--- a/app/Handlers/RequestMade_AwakeTheDatabase.cs
+++ b/app/Handlers/RequestMade_AwakeTheDatabase.cs
@@ -1,0 +1,23 @@
+using app.Notifications;
+using app.Persistence;
+using MediatR;
+
+namespace app.Handlers;
+public class RequestMade_AwakeTheDatabase(AppDbContext dbContext, ILogger<RequestMade_AwakeTheDatabase> logger) : INotificationHandler<RequestMade>
+{
+    private readonly AppDbContext _dbContext = dbContext;
+    private readonly ILogger<RequestMade_AwakeTheDatabase> _logger = logger;
+
+    public async Task Handle(RequestMade notification, CancellationToken cancellationToken)
+    {
+        try
+        {
+            _ = await _dbContext.Database.CanConnectAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "An error occurred while checking the database connection.");
+            return;
+        }
+    }
+}

--- a/app/Middlewares/DatabaseCheckMiddleware.cs
+++ b/app/Middlewares/DatabaseCheckMiddleware.cs
@@ -1,0 +1,14 @@
+using app.Notifications;
+using MediatR;
+
+namespace app.Middlewares;
+public class DatabaseCheckMiddleware(IPublisher publisher) : IMiddleware
+{
+    private readonly IPublisher _publisher = publisher;
+
+    public async Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        await _publisher.Publish(new RequestMade());
+        await next(context);
+    }
+}

--- a/app/Notifications/RequestMade.cs
+++ b/app/Notifications/RequestMade.cs
@@ -1,0 +1,6 @@
+using MediatR;
+
+namespace app.Notifications;
+public struct RequestMade : INotification
+{
+}

--- a/app/Program.cs
+++ b/app/Program.cs
@@ -1,5 +1,6 @@
 using app.Components;
 using app.Extensions;
+using app.Middlewares;
 using EntityFrameworkCore.Seeder.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -28,6 +29,8 @@ if (app.Environment.IsProduction())
 }
 
 app.UseStaticFiles();
+
+app.UseMiddleware<DatabaseCheckMiddleware>();
 
 app.UseAuthentication();
 


### PR DESCRIPTION
request

This is because we use a development database which is cheaper and then uses a lazy load strategy