### PR TITLE
Fix broken icons across the site

### DIFF
--- a/src/app/Components/App.razor
+++ b/src/app/Components/App.razor
@@ -26,9 +26,12 @@
     <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@100..900&family=Noto+Sans:ital,wght@0,100..900;1,100..900&family=Space+Grotesk:wght@300..700&display=swap" rel="stylesheet">
 
     <!-- Phosphor Icons -->
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/@@phosphor-icons/web@2.1.1/src/regular/style.css">
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/@@phosphor-icons/web@2.1.1/src/fill/style.css">
-    <link rel="stylesheet" type="text/css" href="https://unpkg.com/@@phosphor-icons/web@2.1.1/src/duotone/style.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@@phosphor-icons/web@@2.1.1/src/regular/style.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@@phosphor-icons/web@@2.1.1/src/fill/style.css">
+    <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@@phosphor-icons/web@@2.1.1/src/duotone/style.css">
+
+    <!-- Font Awesome -->
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
 
     <base href="/" />
     <link rel="stylesheet" href="@Assets["/app.css"]" />

--- a/src/app/styles/input.css
+++ b/src/app/styles/input.css
@@ -65,14 +65,14 @@
     border-color: var(--color-gray-200, currentcolor);
   }
 
-  body {
+  body, p, span, ul, li, h1, h2, h3, h4 {
     font-family: Lexend, "Noto Sans", system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     font-weight: 300;
   }
 }
 
 @layer components {
-  *{
+  body, p, span, ul, li, h1, h2, h3, h4{
     @apply text-dark-purple;
   }
 

--- a/src/app/styles/input.css
+++ b/src/app/styles/input.css
@@ -62,7 +62,11 @@
   ::before,
   ::backdrop,
   ::file-selector-button {
-    border-color: var(--color-gray-200, currentcolor);font-family: Lexend, "Noto Sans", system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+    border-color: var(--color-gray-200, currentcolor);
+  }
+
+  body {
+    font-family: Lexend, "Noto Sans", system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     font-weight: 300;
   }
 }


### PR DESCRIPTION
## Summary
- Add the missing Font Awesome stylesheet — `fa-solid`, `fa-regular` and `fa-brands` icons are used across Contact, Events, Login, Jobs, Error and the .NET Conf pages but no CSS was ever loaded for them.
- Properly escape the second `@` in the Phosphor CDN URLs (`web@@2.1.1`) and switch to jsdelivr so the version segment is reliably preserved through Razor parsing.
- Scope the default `font-family` / `font-weight` rule to text elements (`body, p, span, ul, li, h1..h4`) instead of `*, ::before, ::after, ...`. The wildcard rule was setting `font-family: Lexend` directly on `::before` pseudo-elements, which overrode the icon fonts (`"Phosphor"`, `"Font Awesome ..."`) on the very pseudo-element that renders the glyph — so icons rendered as tofu boxes.
- Same scoping for the default `text-dark-purple` color rule, so icon colors can inherit from their parent (e.g. `<a class="text-primary"><i class="ph ph-..."></i></a>` now works).

## Test plan
- [x] Hard-refresh the home page — Phosphor icons (arrows, whatsapp, github, globe, hearts, etc.) render correctly
- [x] Contact page — `fa-brands` (discord, linkedin, github, whatsapp, telegram) render
- [x] Jobs pages — `fa-solid` / `fa-brands` icons render
- [x] Error and .NET Conf 2024/2025 pages — FontAwesome icons render
- [x] Icons inside `text-primary` / `text-white` / etc. containers inherit the parent color

🤖 Generated with [Claude Code](https://claude.com/claude-code)