### PR TITLE
Scheduled announcement banners

### DIFF
--- a/src/admin/src/api/banners.ts
+++ b/src/admin/src/api/banners.ts
@@ -1,0 +1,43 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { get, post, put, del } from './client';
+import type { PagedResponse, BannerResponse, CreateOrUpdateBannerRequest } from './types';
+
+export function useBanners(page: number, size: number) {
+  const params = new URLSearchParams({ page: String(page), size: String(size) });
+  return useQuery({
+    queryKey: ['banners', page, size],
+    queryFn: () => get<PagedResponse<BannerResponse>>(`/banners?${params}`),
+  });
+}
+
+export function useBanner(id: string) {
+  return useQuery({
+    queryKey: ['banners', id],
+    queryFn: () => get<BannerResponse>(`/banners/${id}`),
+    enabled: !!id,
+  });
+}
+
+export function useCreateBanner() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateOrUpdateBannerRequest) => post<BannerResponse>('/banners', data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['banners'] }),
+  });
+}
+
+export function useUpdateBanner(id: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateOrUpdateBannerRequest) => put<BannerResponse>(`/banners/${id}`, data),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['banners'] }),
+  });
+}
+
+export function useDeleteBanner() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => del(`/banners/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['banners'] }),
+  });
+}

--- a/src/admin/src/api/types.ts
+++ b/src/admin/src/api/types.ts
@@ -100,6 +100,39 @@ export interface CreateOrUpdatePartnerRequest {
   website: string;
 }
 
+// Banners
+export type BannerVariant = 'Announcement' | 'Advertisement' | 'Promo' | 'Event' | 'Maintenance';
+
+export interface BannerResponse {
+  id: string;
+  messageEn: string;
+  messageFr: string;
+  variant: BannerVariant;
+  startDate: string;
+  endDate: string;
+  link: string | null;
+  linkLabelEn: string | null;
+  linkLabelFr: string | null;
+  dismissible: boolean;
+  priority: number;
+  isEnabled: boolean;
+  createdAt: string;
+}
+
+export interface CreateOrUpdateBannerRequest {
+  messageEn: string;
+  messageFr: string;
+  variant: BannerVariant;
+  startDate: string;
+  endDate: string;
+  link: string | null;
+  linkLabelEn: string | null;
+  linkLabelFr: string | null;
+  dismissible: boolean;
+  priority: number;
+  isEnabled: boolean;
+}
+
 // External Apps
 export interface AppSummary {
   id: string;

--- a/src/admin/src/api/types.ts
+++ b/src/admin/src/api/types.ts
@@ -105,6 +105,10 @@ export type BannerVariant = 'Announcement' | 'Advertisement' | 'Promo' | 'Event'
 
 export interface BannerResponse {
   id: string;
+  titleEn: string | null;
+  titleFr: string | null;
+  subtitleEn: string | null;
+  subtitleFr: string | null;
   messageEn: string;
   messageFr: string;
   variant: BannerVariant;
@@ -120,6 +124,10 @@ export interface BannerResponse {
 }
 
 export interface CreateOrUpdateBannerRequest {
+  titleEn: string | null;
+  titleFr: string | null;
+  subtitleEn: string | null;
+  subtitleFr: string | null;
   messageEn: string;
   messageFr: string;
   variant: BannerVariant;

--- a/src/admin/src/components/AdminSidebar.tsx
+++ b/src/admin/src/components/AdminSidebar.tsx
@@ -4,12 +4,14 @@ import {
   Calendar,
   Handshake,
   KeyRound,
+  Megaphone,
 } from 'lucide-react';
 
 const navItems = [
   { to: '/', label: 'Dashboard', icon: LayoutDashboard, exact: true },
   { to: '/events', label: 'Events', icon: Calendar, exact: false },
   { to: '/partners', label: 'Partners', icon: Handshake, exact: false },
+  { to: '/banners', label: 'Banners', icon: Megaphone, exact: false },
   { to: '/apps', label: 'Applications', icon: KeyRound, exact: false },
 ] as const;
 

--- a/src/admin/src/components/BannerForm.tsx
+++ b/src/admin/src/components/BannerForm.tsx
@@ -24,6 +24,10 @@ export function BannerForm({ bannerId }: BannerFormProps) {
   const createBanner = useCreateBanner();
   const updateBanner = useUpdateBanner(bannerId ?? '');
 
+  const [titleEn, setTitleEn] = useState('');
+  const [titleFr, setTitleFr] = useState('');
+  const [subtitleEn, setSubtitleEn] = useState('');
+  const [subtitleFr, setSubtitleFr] = useState('');
   const [messageEn, setMessageEn] = useState('');
   const [messageFr, setMessageFr] = useState('');
   const [variant, setVariant] = useState<BannerVariant>('Announcement');
@@ -38,6 +42,10 @@ export function BannerForm({ bannerId }: BannerFormProps) {
 
   useEffect(() => {
     if (!existing) return;
+    setTitleEn(existing.titleEn ?? '');
+    setTitleFr(existing.titleFr ?? '');
+    setSubtitleEn(existing.subtitleEn ?? '');
+    setSubtitleFr(existing.subtitleFr ?? '');
     setMessageEn(existing.messageEn);
     setMessageFr(existing.messageFr);
     setVariant(existing.variant);
@@ -54,6 +62,10 @@ export function BannerForm({ bannerId }: BannerFormProps) {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const data: CreateOrUpdateBannerRequest = {
+      titleEn: titleEn.trim() || null,
+      titleFr: titleFr.trim() || null,
+      subtitleEn: subtitleEn.trim() || null,
+      subtitleFr: subtitleFr.trim() || null,
       messageEn,
       messageFr,
       variant,
@@ -107,7 +119,59 @@ export function BannerForm({ bannerId }: BannerFormProps) {
 
       <form onSubmit={handleSubmit} className="space-y-6">
         <div className="card p-6 space-y-4">
-          <h2 className="text-sm font-semibold text-gray-800">Content</h2>
+          <div>
+            <h2 className="text-sm font-semibold text-gray-800">Headline (optional)</h2>
+            <p className="text-xs text-gray-500 mt-0.5">
+              If set, the banner uses the rich layout (title + subtitle + message + CTA).
+              Leave empty for a compact single-line banner.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="label">Title (English)</label>
+              <input
+                value={titleEn}
+                onChange={(e) => setTitleEn(e.target.value)}
+                maxLength={120}
+                className="input"
+                placeholder="AI Skills Fest"
+              />
+            </div>
+            <div>
+              <label className="label">Title (Français)</label>
+              <input
+                value={titleFr}
+                onChange={(e) => setTitleFr(e.target.value)}
+                maxLength={120}
+                className="input"
+                placeholder="Festival des compétences IA"
+              />
+            </div>
+            <div>
+              <label className="label">Subtitle (English)</label>
+              <input
+                value={subtitleEn}
+                onChange={(e) => setSubtitleEn(e.target.value)}
+                maxLength={80}
+                className="input"
+                placeholder="June 8-12, 2026"
+              />
+            </div>
+            <div>
+              <label className="label">Subtitle (Français)</label>
+              <input
+                value={subtitleFr}
+                onChange={(e) => setSubtitleFr(e.target.value)}
+                maxLength={80}
+                className="input"
+                placeholder="8-12 juin 2026"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="card p-6 space-y-4">
+          <h2 className="text-sm font-semibold text-gray-800">Message</h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
               <label className="label">Message (English)</label>
@@ -118,7 +182,7 @@ export function BannerForm({ bannerId }: BannerFormProps) {
                 rows={3}
                 maxLength={500}
                 className="input"
-                placeholder="Short message shown to English visitors"
+                placeholder="Build your AI skills with chances to earn prizes and certification vouchers"
               />
             </div>
             <div>
@@ -130,7 +194,7 @@ export function BannerForm({ bannerId }: BannerFormProps) {
                 rows={3}
                 maxLength={500}
                 className="input"
-                placeholder="Message court affiché aux visiteurs francophones"
+                placeholder="Développez vos compétences en IA avec des prix et bons à gagner"
               />
             </div>
           </div>

--- a/src/admin/src/components/BannerForm.tsx
+++ b/src/admin/src/components/BannerForm.tsx
@@ -1,0 +1,266 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { useBanner, useCreateBanner, useUpdateBanner } from '../api/banners';
+import type { CreateOrUpdateBannerRequest, BannerVariant } from '../api/types';
+import { ArrowLeft, Save, Loader2 } from 'lucide-react';
+
+interface BannerFormProps {
+  bannerId?: string;
+}
+
+const variants: BannerVariant[] = ['Announcement', 'Advertisement', 'Promo', 'Event', 'Maintenance'];
+
+function toLocalInput(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function BannerForm({ bannerId }: BannerFormProps) {
+  const navigate = useNavigate();
+  const isEdit = !!bannerId;
+
+  const { data: existing, isLoading: loadingExisting } = useBanner(bannerId ?? '');
+  const createBanner = useCreateBanner();
+  const updateBanner = useUpdateBanner(bannerId ?? '');
+
+  const [messageEn, setMessageEn] = useState('');
+  const [messageFr, setMessageFr] = useState('');
+  const [variant, setVariant] = useState<BannerVariant>('Announcement');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [link, setLink] = useState('');
+  const [linkLabelEn, setLinkLabelEn] = useState('');
+  const [linkLabelFr, setLinkLabelFr] = useState('');
+  const [dismissible, setDismissible] = useState(true);
+  const [priority, setPriority] = useState(0);
+  const [isEnabled, setIsEnabled] = useState(true);
+
+  useEffect(() => {
+    if (!existing) return;
+    setMessageEn(existing.messageEn);
+    setMessageFr(existing.messageFr);
+    setVariant(existing.variant);
+    setStartDate(toLocalInput(existing.startDate));
+    setEndDate(toLocalInput(existing.endDate));
+    setLink(existing.link ?? '');
+    setLinkLabelEn(existing.linkLabelEn ?? '');
+    setLinkLabelFr(existing.linkLabelFr ?? '');
+    setDismissible(existing.dismissible);
+    setPriority(existing.priority);
+    setIsEnabled(existing.isEnabled);
+  }, [existing]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: CreateOrUpdateBannerRequest = {
+      messageEn,
+      messageFr,
+      variant,
+      startDate: new Date(startDate).toISOString(),
+      endDate: new Date(endDate).toISOString(),
+      link: link.trim() || null,
+      linkLabelEn: linkLabelEn.trim() || null,
+      linkLabelFr: linkLabelFr.trim() || null,
+      dismissible,
+      priority,
+      isEnabled,
+    };
+
+    const onSuccess = () => navigate({ to: '/banners' });
+    if (isEdit) {
+      updateBanner.mutate(data, { onSuccess });
+    } else {
+      createBanner.mutate(data, { onSuccess });
+    }
+  };
+
+  if (isEdit && loadingExisting) {
+    return (
+      <div className="flex items-center justify-center h-48 text-gray-400">
+        <Loader2 size={24} className="animate-spin" />
+      </div>
+    );
+  }
+
+  const saving = createBanner.isPending || updateBanner.isPending;
+
+  return (
+    <div className="max-w-3xl">
+      <div className="flex items-center gap-3 mb-6">
+        <button
+          type="button"
+          onClick={() => navigate({ to: '/banners' })}
+          className="p-2 rounded-lg text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors cursor-pointer"
+        >
+          <ArrowLeft size={18} />
+        </button>
+        <div>
+          <h1 className="text-2xl font-heading font-bold text-gray-900">
+            {isEdit ? 'Edit Banner' : 'New Banner'}
+          </h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Scheduled site-wide announcements
+          </p>
+        </div>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="card p-6 space-y-4">
+          <h2 className="text-sm font-semibold text-gray-800">Content</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="label">Message (English)</label>
+              <textarea
+                required
+                value={messageEn}
+                onChange={(e) => setMessageEn(e.target.value)}
+                rows={3}
+                maxLength={500}
+                className="input"
+                placeholder="Short message shown to English visitors"
+              />
+            </div>
+            <div>
+              <label className="label">Message (Français)</label>
+              <textarea
+                required
+                value={messageFr}
+                onChange={(e) => setMessageFr(e.target.value)}
+                rows={3}
+                maxLength={500}
+                className="input"
+                placeholder="Message court affiché aux visiteurs francophones"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="label">Variant</label>
+            <select
+              value={variant}
+              onChange={(e) => setVariant(e.target.value as BannerVariant)}
+              className="input"
+            >
+              {variants.map((v) => (
+                <option key={v} value={v}>
+                  {v}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="card p-6 space-y-4">
+          <h2 className="text-sm font-semibold text-gray-800">Optional call-to-action</h2>
+          <div>
+            <label className="label">Link URL</label>
+            <input
+              type="url"
+              value={link}
+              onChange={(e) => setLink(e.target.value)}
+              className="input"
+              placeholder="https://..."
+            />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="label">Link label (English)</label>
+              <input
+                value={linkLabelEn}
+                onChange={(e) => setLinkLabelEn(e.target.value)}
+                maxLength={100}
+                className="input"
+                placeholder="Learn more"
+              />
+            </div>
+            <div>
+              <label className="label">Link label (Français)</label>
+              <input
+                value={linkLabelFr}
+                onChange={(e) => setLinkLabelFr(e.target.value)}
+                maxLength={100}
+                className="input"
+                placeholder="En savoir plus"
+              />
+            </div>
+          </div>
+        </div>
+
+        <div className="card p-6 space-y-4">
+          <h2 className="text-sm font-semibold text-gray-800">Schedule &amp; behavior</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="label">Start date</label>
+              <input
+                required
+                type="datetime-local"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                className="input"
+              />
+            </div>
+            <div>
+              <label className="label">End date</label>
+              <input
+                required
+                type="datetime-local"
+                value={endDate}
+                onChange={(e) => setEndDate(e.target.value)}
+                className="input"
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div>
+              <label className="label">Priority</label>
+              <input
+                type="number"
+                value={priority}
+                onChange={(e) => setPriority(Number(e.target.value))}
+                className="input"
+              />
+              <p className="text-xs text-gray-400 mt-1">Higher shows on top</p>
+            </div>
+            <label className="flex items-center gap-2 text-sm text-gray-700 mt-7">
+              <input
+                type="checkbox"
+                checked={dismissible}
+                onChange={(e) => setDismissible(e.target.checked)}
+              />
+              Dismissible by visitors
+            </label>
+            <label className="flex items-center gap-2 text-sm text-gray-700 mt-7">
+              <input
+                type="checkbox"
+                checked={isEnabled}
+                onChange={(e) => setIsEnabled(e.target.checked)}
+              />
+              Enabled
+            </label>
+          </div>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={() => navigate({ to: '/banners' })}
+            className="btn btn-outline"
+          >
+            Cancel
+          </button>
+          <button type="submit" disabled={saving} className="btn btn-primary">
+            {saving ? (
+              <>
+                <Loader2 size={14} className="animate-spin" /> Saving...
+              </>
+            ) : (
+              <>
+                <Save size={14} /> {isEdit ? 'Save changes' : 'Create banner'}
+              </>
+            )}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/admin/src/routeTree.gen.ts
+++ b/src/admin/src/routeTree.gen.ts
@@ -12,10 +12,13 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as PartnersIndexRouteImport } from './routes/partners/index'
 import { Route as EventsIndexRouteImport } from './routes/events/index'
+import { Route as BannersIndexRouteImport } from './routes/banners/index'
 import { Route as AppsIndexRouteImport } from './routes/apps/index'
 import { Route as EventsNewRouteImport } from './routes/events/new'
+import { Route as BannersNewRouteImport } from './routes/banners/new'
 import { Route as AppsRegisterRouteImport } from './routes/apps/register'
 import { Route as EventsIdEditRouteImport } from './routes/events/$id.edit'
+import { Route as BannersIdEditRouteImport } from './routes/banners/$id.edit'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -32,6 +35,11 @@ const EventsIndexRoute = EventsIndexRouteImport.update({
   path: '/events/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const BannersIndexRoute = BannersIndexRouteImport.update({
+  id: '/banners/',
+  path: '/banners/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AppsIndexRoute = AppsIndexRouteImport.update({
   id: '/apps/',
   path: '/apps/',
@@ -40,6 +48,11 @@ const AppsIndexRoute = AppsIndexRouteImport.update({
 const EventsNewRoute = EventsNewRouteImport.update({
   id: '/events/new',
   path: '/events/new',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const BannersNewRoute = BannersNewRouteImport.update({
+  id: '/banners/new',
+  path: '/banners/new',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AppsRegisterRoute = AppsRegisterRouteImport.update({
@@ -52,33 +65,47 @@ const EventsIdEditRoute = EventsIdEditRouteImport.update({
   path: '/events/$id/edit',
   getParentRoute: () => rootRouteImport,
 } as any)
+const BannersIdEditRoute = BannersIdEditRouteImport.update({
+  id: '/banners/$id/edit',
+  path: '/banners/$id/edit',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/apps/register': typeof AppsRegisterRoute
+  '/banners/new': typeof BannersNewRoute
   '/events/new': typeof EventsNewRoute
   '/apps/': typeof AppsIndexRoute
+  '/banners/': typeof BannersIndexRoute
   '/events/': typeof EventsIndexRoute
   '/partners/': typeof PartnersIndexRoute
+  '/banners/$id/edit': typeof BannersIdEditRoute
   '/events/$id/edit': typeof EventsIdEditRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/apps/register': typeof AppsRegisterRoute
+  '/banners/new': typeof BannersNewRoute
   '/events/new': typeof EventsNewRoute
   '/apps': typeof AppsIndexRoute
+  '/banners': typeof BannersIndexRoute
   '/events': typeof EventsIndexRoute
   '/partners': typeof PartnersIndexRoute
+  '/banners/$id/edit': typeof BannersIdEditRoute
   '/events/$id/edit': typeof EventsIdEditRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/apps/register': typeof AppsRegisterRoute
+  '/banners/new': typeof BannersNewRoute
   '/events/new': typeof EventsNewRoute
   '/apps/': typeof AppsIndexRoute
+  '/banners/': typeof BannersIndexRoute
   '/events/': typeof EventsIndexRoute
   '/partners/': typeof PartnersIndexRoute
+  '/banners/$id/edit': typeof BannersIdEditRoute
   '/events/$id/edit': typeof EventsIdEditRoute
 }
 export interface FileRouteTypes {
@@ -86,38 +113,50 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/apps/register'
+    | '/banners/new'
     | '/events/new'
     | '/apps/'
+    | '/banners/'
     | '/events/'
     | '/partners/'
+    | '/banners/$id/edit'
     | '/events/$id/edit'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/apps/register'
+    | '/banners/new'
     | '/events/new'
     | '/apps'
+    | '/banners'
     | '/events'
     | '/partners'
+    | '/banners/$id/edit'
     | '/events/$id/edit'
   id:
     | '__root__'
     | '/'
     | '/apps/register'
+    | '/banners/new'
     | '/events/new'
     | '/apps/'
+    | '/banners/'
     | '/events/'
     | '/partners/'
+    | '/banners/$id/edit'
     | '/events/$id/edit'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AppsRegisterRoute: typeof AppsRegisterRoute
+  BannersNewRoute: typeof BannersNewRoute
   EventsNewRoute: typeof EventsNewRoute
   AppsIndexRoute: typeof AppsIndexRoute
+  BannersIndexRoute: typeof BannersIndexRoute
   EventsIndexRoute: typeof EventsIndexRoute
   PartnersIndexRoute: typeof PartnersIndexRoute
+  BannersIdEditRoute: typeof BannersIdEditRoute
   EventsIdEditRoute: typeof EventsIdEditRoute
 }
 
@@ -144,6 +183,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/banners/': {
+      id: '/banners/'
+      path: '/banners'
+      fullPath: '/banners/'
+      preLoaderRoute: typeof BannersIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/apps/': {
       id: '/apps/'
       path: '/apps'
@@ -156,6 +202,13 @@ declare module '@tanstack/react-router' {
       path: '/events/new'
       fullPath: '/events/new'
       preLoaderRoute: typeof EventsNewRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/banners/new': {
+      id: '/banners/new'
+      path: '/banners/new'
+      fullPath: '/banners/new'
+      preLoaderRoute: typeof BannersNewRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/apps/register': {
@@ -172,16 +225,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsIdEditRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/banners/$id/edit': {
+      id: '/banners/$id/edit'
+      path: '/banners/$id/edit'
+      fullPath: '/banners/$id/edit'
+      preLoaderRoute: typeof BannersIdEditRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AppsRegisterRoute: AppsRegisterRoute,
+  BannersNewRoute: BannersNewRoute,
   EventsNewRoute: EventsNewRoute,
   AppsIndexRoute: AppsIndexRoute,
+  BannersIndexRoute: BannersIndexRoute,
   EventsIndexRoute: EventsIndexRoute,
   PartnersIndexRoute: PartnersIndexRoute,
+  BannersIdEditRoute: BannersIdEditRoute,
   EventsIdEditRoute: EventsIdEditRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/admin/src/routes/banners/$id.edit.tsx
+++ b/src/admin/src/routes/banners/$id.edit.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { BannerForm } from '../../components/BannerForm';
+
+export const Route = createFileRoute('/banners/$id/edit')({
+  component: EditBannerPage,
+});
+
+function EditBannerPage() {
+  const { id } = Route.useParams();
+  return <BannerForm bannerId={id} />;
+}

--- a/src/admin/src/routes/banners/index.tsx
+++ b/src/admin/src/routes/banners/index.tsx
@@ -75,8 +75,13 @@ function BannersListPage() {
                   const active = isActiveNow(b.startDate, b.endDate, b.isEnabled);
                   return (
                     <tr key={b.id} className="hover:bg-gray-50/50 transition-colors">
-                      <td className="px-5 py-3.5 font-medium text-gray-800 max-w-md truncate">
-                        {b.messageEn}
+                      <td className="px-5 py-3.5 max-w-md">
+                        {b.titleEn && (
+                          <div className="font-semibold text-gray-900 truncate">{b.titleEn}</div>
+                        )}
+                        <div className={`${b.titleEn ? 'text-xs text-gray-500' : 'font-medium text-gray-800'} truncate`}>
+                          {b.messageEn}
+                        </div>
                       </td>
                       <td className="px-5 py-3.5">
                         <span className={variantBadge[b.variant]}>{b.variant}</span>

--- a/src/admin/src/routes/banners/index.tsx
+++ b/src/admin/src/routes/banners/index.tsx
@@ -1,0 +1,143 @@
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
+import { useBanners, useDeleteBanner } from '../../api/banners';
+import { Pagination } from '../../components/Pagination';
+import type { BannerVariant } from '../../api/types';
+import { Plus, Pencil, Trash2, Megaphone, Loader2, CircleDot, CircleOff } from 'lucide-react';
+
+export const Route = createFileRoute('/banners/')({
+  component: BannersListPage,
+});
+
+const variantBadge: Record<BannerVariant, string> = {
+  Announcement: 'badge bg-secondary/10 text-secondary',
+  Advertisement: 'badge bg-tertiary/15 text-tertiary',
+  Promo: 'badge bg-primary/10 text-primary',
+  Event: 'badge bg-dark-purple/10 text-dark-purple',
+  Maintenance: 'badge bg-amber-500/10 text-amber-700',
+};
+
+function isActiveNow(start: string, end: string, isEnabled: boolean) {
+  if (!isEnabled) return false;
+  const now = new Date();
+  return new Date(start) <= now && new Date(end) >= now;
+}
+
+function BannersListPage() {
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = useBanners(page, 10);
+  const deleteBanner = useDeleteBanner();
+  const navigate = useNavigate();
+
+  return (
+    <div className="max-w-5xl">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-heading font-bold text-gray-900">Banners</h1>
+          <p className="text-sm text-gray-500 mt-1">
+            Site-wide announcements scheduled by start &amp; end date
+          </p>
+        </div>
+        <Link to="/banners/new" className="btn btn-primary">
+          <Plus size={16} />
+          New Banner
+        </Link>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center h-48 text-gray-400">
+          <Loader2 size={24} className="animate-spin" />
+        </div>
+      ) : !data?.items.length ? (
+        <div className="card flex flex-col items-center justify-center py-20 text-gray-400">
+          <Megaphone size={36} strokeWidth={1.2} />
+          <p className="mt-3 text-sm">No banners yet</p>
+          <Link to="/banners/new" className="btn btn-primary btn-sm mt-4">
+            <Plus size={14} />
+            Create your first banner
+          </Link>
+        </div>
+      ) : (
+        <>
+          <div className="card overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-gray-100 bg-gray-50/60">
+                  <th className="text-left px-5 py-3 section-title text-[11px]">Message</th>
+                  <th className="text-left px-5 py-3 section-title text-[11px]">Variant</th>
+                  <th className="text-left px-5 py-3 section-title text-[11px]">Schedule</th>
+                  <th className="text-left px-5 py-3 section-title text-[11px]">Status</th>
+                  <th className="text-right px-5 py-3 section-title text-[11px]">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {data.items.map((b) => {
+                  const active = isActiveNow(b.startDate, b.endDate, b.isEnabled);
+                  return (
+                    <tr key={b.id} className="hover:bg-gray-50/50 transition-colors">
+                      <td className="px-5 py-3.5 font-medium text-gray-800 max-w-md truncate">
+                        {b.messageEn}
+                      </td>
+                      <td className="px-5 py-3.5">
+                        <span className={variantBadge[b.variant]}>{b.variant}</span>
+                      </td>
+                      <td className="px-5 py-3.5 text-gray-500 tabular-nums text-xs">
+                        {new Date(b.startDate).toLocaleDateString()} →{' '}
+                        {new Date(b.endDate).toLocaleDateString()}
+                      </td>
+                      <td className="px-5 py-3.5">
+                        {active ? (
+                          <span className="inline-flex items-center gap-1 text-xs text-primary font-medium">
+                            <CircleDot size={12} /> Live
+                          </span>
+                        ) : (
+                          <span className="inline-flex items-center gap-1 text-xs text-gray-400">
+                            <CircleOff size={12} />
+                            {b.isEnabled ? 'Scheduled' : 'Disabled'}
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-5 py-3.5 text-right">
+                        <div className="flex items-center justify-end gap-0.5">
+                          <Link
+                            to="/banners/$id/edit"
+                            params={{ id: b.id }}
+                            className="p-2 rounded-lg text-gray-400 hover:text-secondary hover:bg-secondary/5 transition-colors"
+                            title="Edit"
+                          >
+                            <Pencil size={15} />
+                          </Link>
+                          <button
+                            onClick={() => {
+                              if (confirm('Delete this banner?')) {
+                                deleteBanner.mutate(b.id, {
+                                  onSuccess: () => navigate({ to: '/banners' }),
+                                });
+                              }
+                            }}
+                            className="p-2 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors cursor-pointer"
+                            title="Delete"
+                          >
+                            <Trash2 size={15} />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <Pagination
+            page={data.pageNumber}
+            totalPages={data.totalPages}
+            hasPrevious={data.hasPreviousPage}
+            hasNext={data.hasNextPage}
+            onPageChange={setPage}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/admin/src/routes/banners/new.tsx
+++ b/src/admin/src/routes/banners/new.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { BannerForm } from '../../components/BannerForm';
+
+export const Route = createFileRoute('/banners/new')({
+  component: () => <BannerForm />,
+});

--- a/src/app.business/Services/IBannerService.cs
+++ b/src/app.business/Services/IBannerService.cs
@@ -1,0 +1,16 @@
+using app.domain.Models.BannerAggregate;
+using app.domain.ViewModels;
+using app.shared.Utilities;
+using ErrorOr;
+
+namespace app.business.Services;
+
+public interface IBannerService
+{
+    Task<ErrorOr<PagedList<Banner>>> GetAllAsync(int page = 1, int size = 10, CancellationToken cancellationToken = default);
+    Task<ErrorOr<Banner>> GetAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<Banner[]> GetActiveAsync(CancellationToken cancellationToken = default);
+    Task<ErrorOr<Banner>> CreateAsync(BannerModel model, CancellationToken cancellationToken = default);
+    Task<ErrorOr<Banner>> UpdateAsync(Guid id, BannerModel model, CancellationToken cancellationToken = default);
+    Task<ErrorOr<bool>> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
+}

--- a/src/app.domain/Models/BannerAggregate/Banner.cs
+++ b/src/app.domain/Models/BannerAggregate/Banner.cs
@@ -8,6 +8,10 @@ public sealed class Banner : Entity<Guid>, IAggregateRoot
 {
     private readonly List<IDomainEvent> _domainEvents = [];
 
+    public string? TitleEn { get; private set; }
+    public string? TitleFr { get; private set; }
+    public string? SubtitleEn { get; private set; }
+    public string? SubtitleFr { get; private set; }
     public string MessageEn { get; private set; } = string.Empty;
     public string MessageFr { get; private set; } = string.Empty;
     public BannerVariant Variant { get; private set; }
@@ -24,6 +28,10 @@ public sealed class Banner : Entity<Guid>, IAggregateRoot
 
     private Banner(
         Guid id,
+        string? titleEn,
+        string? titleFr,
+        string? subtitleEn,
+        string? subtitleFr,
         string messageEn,
         string messageFr,
         BannerVariant variant,
@@ -37,6 +45,10 @@ public sealed class Banner : Entity<Guid>, IAggregateRoot
         bool isEnabled,
         DateTime createdAt) : base(id)
     {
+        TitleEn = titleEn;
+        TitleFr = titleFr;
+        SubtitleEn = subtitleEn;
+        SubtitleFr = subtitleFr;
         MessageEn = messageEn;
         MessageFr = messageFr;
         Variant = variant;
@@ -69,6 +81,10 @@ public sealed class Banner : Entity<Guid>, IAggregateRoot
     {
         return new Banner(
             Guid.NewGuid(),
+            model.TitleEn,
+            model.TitleFr,
+            model.SubtitleEn,
+            model.SubtitleFr,
             model.MessageEn,
             model.MessageFr,
             model.Variant,
@@ -85,6 +101,10 @@ public sealed class Banner : Entity<Guid>, IAggregateRoot
 
     public void Update(BannerModel model)
     {
+        TitleEn = model.TitleEn;
+        TitleFr = model.TitleFr;
+        SubtitleEn = model.SubtitleEn;
+        SubtitleFr = model.SubtitleFr;
         MessageEn = model.MessageEn;
         MessageFr = model.MessageFr;
         Variant = model.Variant;

--- a/src/app.domain/Models/BannerAggregate/Banner.cs
+++ b/src/app.domain/Models/BannerAggregate/Banner.cs
@@ -1,0 +1,100 @@
+using app.domain.Models.BannerAggregate.Enums;
+using app.domain.Models.Common;
+using app.domain.ViewModels;
+
+namespace app.domain.Models.BannerAggregate;
+
+public sealed class Banner : Entity<Guid>, IAggregateRoot
+{
+    private readonly List<IDomainEvent> _domainEvents = [];
+
+    public string MessageEn { get; private set; } = string.Empty;
+    public string MessageFr { get; private set; } = string.Empty;
+    public BannerVariant Variant { get; private set; }
+    public DateTime StartDate { get; private set; }
+    public DateTime EndDate { get; private set; }
+    public string? Link { get; private set; }
+    public string? LinkLabelEn { get; private set; }
+    public string? LinkLabelFr { get; private set; }
+    public bool Dismissible { get; private set; }
+    public int Priority { get; private set; }
+    public bool IsEnabled { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public IReadOnlyList<IDomainEvent> DomainEvents => [.. _domainEvents];
+
+    private Banner(
+        Guid id,
+        string messageEn,
+        string messageFr,
+        BannerVariant variant,
+        DateTime startDate,
+        DateTime endDate,
+        string? link,
+        string? linkLabelEn,
+        string? linkLabelFr,
+        bool dismissible,
+        int priority,
+        bool isEnabled,
+        DateTime createdAt) : base(id)
+    {
+        MessageEn = messageEn;
+        MessageFr = messageFr;
+        Variant = variant;
+        StartDate = startDate;
+        EndDate = endDate;
+        Link = link;
+        LinkLabelEn = linkLabelEn;
+        LinkLabelFr = linkLabelFr;
+        Dismissible = dismissible;
+        Priority = priority;
+        IsEnabled = isEnabled;
+        CreatedAt = createdAt;
+    }
+
+    public Banner()
+    {
+    }
+
+    public void RaiseDomainEvent(IDomainEvent domainEvent)
+    {
+        _domainEvents.Add(domainEvent);
+    }
+
+    public void ClearDomainEvents()
+    {
+        _domainEvents.Clear();
+    }
+
+    public static Banner Create(BannerModel model)
+    {
+        return new Banner(
+            Guid.NewGuid(),
+            model.MessageEn,
+            model.MessageFr,
+            model.Variant,
+            DateTime.SpecifyKind(model.StartDate, DateTimeKind.Utc),
+            DateTime.SpecifyKind(model.EndDate, DateTimeKind.Utc),
+            model.Link,
+            model.LinkLabelEn,
+            model.LinkLabelFr,
+            model.Dismissible,
+            model.Priority,
+            model.IsEnabled,
+            DateTime.UtcNow);
+    }
+
+    public void Update(BannerModel model)
+    {
+        MessageEn = model.MessageEn;
+        MessageFr = model.MessageFr;
+        Variant = model.Variant;
+        StartDate = DateTime.SpecifyKind(model.StartDate, DateTimeKind.Utc);
+        EndDate = DateTime.SpecifyKind(model.EndDate, DateTimeKind.Utc);
+        Link = model.Link;
+        LinkLabelEn = model.LinkLabelEn;
+        LinkLabelFr = model.LinkLabelFr;
+        Dismissible = model.Dismissible;
+        Priority = model.Priority;
+        IsEnabled = model.IsEnabled;
+    }
+}

--- a/src/app.domain/Models/BannerAggregate/Enums/BannerVariant.cs
+++ b/src/app.domain/Models/BannerAggregate/Enums/BannerVariant.cs
@@ -1,0 +1,10 @@
+namespace app.domain.Models.BannerAggregate.Enums;
+
+public enum BannerVariant
+{
+    Announcement = 0,
+    Advertisement = 1,
+    Promo = 2,
+    Event = 3,
+    Maintenance = 4,
+}

--- a/src/app.domain/ViewModels/BannerModel.cs
+++ b/src/app.domain/ViewModels/BannerModel.cs
@@ -1,0 +1,18 @@
+using app.domain.Models.BannerAggregate.Enums;
+
+namespace app.domain.ViewModels;
+
+public class BannerModel
+{
+    public string MessageEn { get; set; } = string.Empty;
+    public string MessageFr { get; set; } = string.Empty;
+    public BannerVariant Variant { get; set; }
+    public DateTime StartDate { get; set; }
+    public DateTime EndDate { get; set; }
+    public string? Link { get; set; }
+    public string? LinkLabelEn { get; set; }
+    public string? LinkLabelFr { get; set; }
+    public bool Dismissible { get; set; }
+    public int Priority { get; set; }
+    public bool IsEnabled { get; set; } = true;
+}

--- a/src/app.domain/ViewModels/BannerModel.cs
+++ b/src/app.domain/ViewModels/BannerModel.cs
@@ -4,6 +4,10 @@ namespace app.domain.ViewModels;
 
 public class BannerModel
 {
+    public string? TitleEn { get; set; }
+    public string? TitleFr { get; set; }
+    public string? SubtitleEn { get; set; }
+    public string? SubtitleFr { get; set; }
     public string MessageEn { get; set; } = string.Empty;
     public string MessageFr { get; set; } = string.Empty;
     public BannerVariant Variant { get; set; }

--- a/src/app.infrastructure/Migrations/20260607083704_Add Banners Table.Designer.cs
+++ b/src/app.infrastructure/Migrations/20260607083704_Add Banners Table.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using app.infrastructure.Persistence;
 
@@ -12,9 +13,11 @@ using app.infrastructure.Persistence;
 namespace app.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260607083704_Add Banners Table")]
+    partial class AddBannersTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/app.infrastructure/Migrations/20260607083704_Add Banners Table.cs
+++ b/src/app.infrastructure/Migrations/20260607083704_Add Banners Table.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace app.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBannersTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Banners",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    MessageEn = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    MessageFr = table.Column<string>(type: "nvarchar(500)", maxLength: 500, nullable: false),
+                    Variant = table.Column<int>(type: "int", nullable: false),
+                    StartDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    EndDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Link = table.Column<string>(type: "nvarchar(2048)", maxLength: 2048, nullable: true),
+                    LinkLabelEn = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    LinkLabelFr = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                    Dismissible = table.Column<bool>(type: "bit", nullable: false),
+                    Priority = table.Column<int>(type: "int", nullable: false),
+                    IsEnabled = table.Column<bool>(type: "bit", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Banners", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Banners_IsEnabled_StartDate_EndDate",
+                table: "Banners",
+                columns: new[] { "IsEnabled", "StartDate", "EndDate" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Banners");
+        }
+    }
+}

--- a/src/app.infrastructure/Migrations/20260607085745_Add Banner Title And Subtitle.Designer.cs
+++ b/src/app.infrastructure/Migrations/20260607085745_Add Banner Title And Subtitle.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using app.infrastructure.Persistence;
 
@@ -12,9 +13,11 @@ using app.infrastructure.Persistence;
 namespace app.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260607085745_Add Banner Title And Subtitle")]
+    partial class AddBannerTitleAndSubtitle
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/app.infrastructure/Migrations/20260607085745_Add Banner Title And Subtitle.cs
+++ b/src/app.infrastructure/Migrations/20260607085745_Add Banner Title And Subtitle.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace app.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddBannerTitleAndSubtitle : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "SubtitleEn",
+                table: "Banners",
+                type: "nvarchar(80)",
+                maxLength: 80,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "SubtitleFr",
+                table: "Banners",
+                type: "nvarchar(80)",
+                maxLength: 80,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TitleEn",
+                table: "Banners",
+                type: "nvarchar(120)",
+                maxLength: 120,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "TitleFr",
+                table: "Banners",
+                type: "nvarchar(120)",
+                maxLength: 120,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "SubtitleEn",
+                table: "Banners");
+
+            migrationBuilder.DropColumn(
+                name: "SubtitleFr",
+                table: "Banners");
+
+            migrationBuilder.DropColumn(
+                name: "TitleEn",
+                table: "Banners");
+
+            migrationBuilder.DropColumn(
+                name: "TitleFr",
+                table: "Banners");
+        }
+    }
+}

--- a/src/app.infrastructure/Persistence/AppDbContext.cs
+++ b/src/app.infrastructure/Persistence/AppDbContext.cs
@@ -1,3 +1,4 @@
+using app.domain.Models.BannerAggregate;
 using app.domain.Models.Common;
 using app.domain.Models.EventAggregate;
 using app.domain.Models.EventAggregate.Entities;
@@ -15,6 +16,7 @@ public sealed partial class AppDbContext(
     private readonly DomainEventsInterceptor _domainEventsInterceptor = domainEventsInterceptor;
     public DbSet<Event> Events { get; set; }
     public DbSet<Partner> Partners { get; set; }
+    public DbSet<Banner> Banners { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {

--- a/src/app.infrastructure/Persistence/Configurations/BannerConfigurations.cs
+++ b/src/app.infrastructure/Persistence/Configurations/BannerConfigurations.cs
@@ -1,0 +1,19 @@
+using app.domain.Models.BannerAggregate;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace app.infrastructure.Persistence.Configurations;
+
+public class BannerConfigurations : IEntityTypeConfiguration<Banner>
+{
+    public void Configure(EntityTypeBuilder<Banner> builder)
+    {
+        builder.ToTable("Banners");
+        builder.Property(b => b.MessageEn).IsRequired().HasMaxLength(500);
+        builder.Property(b => b.MessageFr).IsRequired().HasMaxLength(500);
+        builder.Property(b => b.Link).HasMaxLength(2048);
+        builder.Property(b => b.LinkLabelEn).HasMaxLength(100);
+        builder.Property(b => b.LinkLabelFr).HasMaxLength(100);
+        builder.HasIndex(b => new { b.IsEnabled, b.StartDate, b.EndDate });
+    }
+}

--- a/src/app.infrastructure/Persistence/Configurations/BannerConfigurations.cs
+++ b/src/app.infrastructure/Persistence/Configurations/BannerConfigurations.cs
@@ -9,6 +9,10 @@ public class BannerConfigurations : IEntityTypeConfiguration<Banner>
     public void Configure(EntityTypeBuilder<Banner> builder)
     {
         builder.ToTable("Banners");
+        builder.Property(b => b.TitleEn).HasMaxLength(120);
+        builder.Property(b => b.TitleFr).HasMaxLength(120);
+        builder.Property(b => b.SubtitleEn).HasMaxLength(80);
+        builder.Property(b => b.SubtitleFr).HasMaxLength(80);
         builder.Property(b => b.MessageEn).IsRequired().HasMaxLength(500);
         builder.Property(b => b.MessageFr).IsRequired().HasMaxLength(500);
         builder.Property(b => b.Link).HasMaxLength(2048);

--- a/src/app.infrastructure/Services/BannerService.cs
+++ b/src/app.infrastructure/Services/BannerService.cs
@@ -1,0 +1,113 @@
+using app.business.Persistence;
+using app.business.Services;
+using app.domain.Models.BannerAggregate;
+using app.domain.ViewModels;
+using app.infrastructure.Persistence.Repositories.Base;
+using app.shared.Utilities;
+using ErrorOr;
+using Microsoft.EntityFrameworkCore;
+
+namespace app.infrastructure.Services;
+
+public class BannerService(
+    IUnitOfWork unitOfWork,
+    IRepository<Banner, Guid> bannerRepository,
+    ICacheManager cacheManager) : IBannerService
+{
+    private const string ActiveBannersCacheKey = "banners-active";
+
+    public async Task<ErrorOr<PagedList<Banner>>> GetAllAsync(int page = 1, int size = 10, CancellationToken cancellationToken = default)
+    {
+        var totalCount = await bannerRepository.Table.CountAsync(cancellationToken);
+        var banners = await bannerRepository
+            .Table
+            .OrderByDescending(b => b.CreatedAt)
+            .Skip((page - 1) * size)
+            .Take(size)
+            .ToListAsync(cancellationToken);
+
+        return PagedList.FromList(banners, totalCount, page, size);
+    }
+
+    public async Task<ErrorOr<Banner>> GetAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var banner = await bannerRepository.GetAsync(id, cancellationToken);
+        if (banner is null)
+        {
+            return Error.NotFound("Banner.NotFound", "Banner not found");
+        }
+
+        return banner;
+    }
+
+    public async Task<Banner[]> GetActiveAsync(CancellationToken cancellationToken = default)
+    {
+        var banners = await cacheManager.GetOrCreateAsync(
+            ActiveBannersCacheKey,
+            entry =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5);
+                var now = DateTime.UtcNow;
+                return bannerRepository
+                    .Table
+                    .Where(b => b.IsEnabled && b.StartDate <= now && b.EndDate >= now)
+                    .OrderByDescending(b => b.Priority)
+                    .ThenBy(b => b.CreatedAt)
+                    .ToArrayAsync(cancellationToken);
+            });
+
+        return banners ?? [];
+    }
+
+    public async Task<ErrorOr<Banner>> CreateAsync(BannerModel model, CancellationToken cancellationToken = default)
+    {
+        if (model.EndDate <= model.StartDate)
+        {
+            return Error.Validation("Banner.InvalidSchedule", "End date must be after start date");
+        }
+
+        var banner = Banner.Create(model);
+        banner = await bannerRepository.AddAsync(banner, cancellationToken);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        ClearBannerCache();
+        return banner;
+    }
+
+    public async Task<ErrorOr<Banner>> UpdateAsync(Guid id, BannerModel model, CancellationToken cancellationToken = default)
+    {
+        if (model.EndDate <= model.StartDate)
+        {
+            return Error.Validation("Banner.InvalidSchedule", "End date must be after start date");
+        }
+
+        var banner = await bannerRepository.GetAsync(id, cancellationToken);
+        if (banner is null)
+        {
+            return Error.NotFound("Banner.NotFound", "Banner not found");
+        }
+
+        banner.Update(model);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+        ClearBannerCache();
+        return banner;
+    }
+
+    public async Task<ErrorOr<bool>> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var deleted = await bannerRepository.DeleteAsync(id, cancellationToken);
+        if (deleted)
+        {
+            ClearBannerCache();
+        }
+        return deleted;
+    }
+
+    private void ClearBannerCache()
+    {
+        var keys = cacheManager.GetKeys().Where(k => k.Contains("banners"));
+        foreach (var key in keys)
+        {
+            cacheManager.Remove(key);
+        }
+    }
+}

--- a/src/app/Api/Admin/AdminApi.cs
+++ b/src/app/Api/Admin/AdminApi.cs
@@ -16,6 +16,7 @@ public static class AdminApi
         group.MapAdminPartnersApi();
         group.MapAdminAppsApi();
         group.MapAdminFilesApi();
+        group.MapAdminBannersApi();
 
         return endpoints;
     }

--- a/src/app/Api/Admin/AdminBannersApi.cs
+++ b/src/app/Api/Admin/AdminBannersApi.cs
@@ -1,0 +1,119 @@
+using app.Api.Admin.Dtos;
+using app.business.Services;
+using app.domain.Models.BannerAggregate;
+using app.domain.ViewModels;
+
+namespace app.Api.Admin;
+
+public static class AdminBannersApi
+{
+    public static RouteGroupBuilder MapAdminBannersApi(this RouteGroupBuilder group)
+    {
+        group.MapGet("/banners", async (
+            int? page,
+            int? size,
+            IBannerService bannerService,
+            CancellationToken ct) =>
+        {
+            var p = page ?? 1;
+            var s = size ?? 10;
+
+            var result = await bannerService.GetAllAsync(p, s, ct);
+            if (result.IsError)
+                return Results.Problem(result.FirstError.Description);
+
+            var pagedList = result.Value;
+            var response = new PagedResponse<BannerResponse>(
+                pagedList.Items.Select(MapToResponse).ToList(),
+                pagedList.TotalCount,
+                pagedList.PageNumber,
+                pagedList.PageSize,
+                pagedList.TotalPages,
+                pagedList.HasPreviousPage,
+                pagedList.HasNextPage);
+
+            return Results.Ok(response);
+        });
+
+        group.MapGet("/banners/{id:guid}", async (
+            Guid id,
+            IBannerService bannerService,
+            CancellationToken ct) =>
+        {
+            var result = await bannerService.GetAsync(id, ct);
+            if (result.IsError)
+                return Results.NotFound(result.FirstError.Description);
+
+            return Results.Ok(MapToResponse(result.Value));
+        });
+
+        group.MapPost("/banners", async (
+            CreateOrUpdateBannerRequest request,
+            IBannerService bannerService,
+            CancellationToken ct) =>
+        {
+            var result = await bannerService.CreateAsync(MapToModel(request), ct);
+            if (result.IsError)
+                return Results.Problem(result.FirstError.Description);
+
+            return Results.Created($"/api/admin/banners/{result.Value.Id}", MapToResponse(result.Value));
+        });
+
+        group.MapPut("/banners/{id:guid}", async (
+            Guid id,
+            CreateOrUpdateBannerRequest request,
+            IBannerService bannerService,
+            CancellationToken ct) =>
+        {
+            var result = await bannerService.UpdateAsync(id, MapToModel(request), ct);
+            if (result.IsError)
+                return Results.Problem(result.FirstError.Description);
+
+            return Results.Ok(MapToResponse(result.Value));
+        });
+
+        group.MapDelete("/banners/{id:guid}", async (
+            Guid id,
+            IBannerService bannerService,
+            CancellationToken ct) =>
+        {
+            var result = await bannerService.DeleteAsync(id, ct);
+            if (result.IsError)
+                return Results.Problem(result.FirstError.Description);
+
+            return Results.NoContent();
+        });
+
+        return group;
+    }
+
+    private static BannerResponse MapToResponse(Banner b) => new(
+        b.Id,
+        b.MessageEn,
+        b.MessageFr,
+        b.Variant,
+        b.StartDate,
+        b.EndDate,
+        b.Link,
+        b.LinkLabelEn,
+        b.LinkLabelFr,
+        b.Dismissible,
+        b.Priority,
+        b.IsEnabled,
+        b.CreatedAt);
+
+    private static BannerModel MapToModel(CreateOrUpdateBannerRequest r) => new()
+    {
+        MessageEn = r.MessageEn,
+        MessageFr = r.MessageFr,
+        Variant = r.Variant,
+        StartDate = r.StartDate,
+        EndDate = r.EndDate,
+        Link = r.Link,
+        LinkLabelEn = r.LinkLabelEn,
+        LinkLabelFr = r.LinkLabelFr,
+        Dismissible = r.Dismissible,
+        Priority = r.Priority,
+        IsEnabled = r.IsEnabled,
+    };
+}

--- a/src/app/Api/Admin/AdminBannersApi.cs
+++ b/src/app/Api/Admin/AdminBannersApi.cs
@@ -89,6 +89,10 @@ public static class AdminBannersApi
 
     private static BannerResponse MapToResponse(Banner b) => new(
         b.Id,
+        b.TitleEn,
+        b.TitleFr,
+        b.SubtitleEn,
+        b.SubtitleFr,
         b.MessageEn,
         b.MessageFr,
         b.Variant,
@@ -104,6 +108,10 @@ public static class AdminBannersApi
 
     private static BannerModel MapToModel(CreateOrUpdateBannerRequest r) => new()
     {
+        TitleEn = r.TitleEn,
+        TitleFr = r.TitleFr,
+        SubtitleEn = r.SubtitleEn,
+        SubtitleFr = r.SubtitleFr,
         MessageEn = r.MessageEn,
         MessageFr = r.MessageFr,
         Variant = r.Variant,

--- a/src/app/Api/Admin/Dtos/BannerDtos.cs
+++ b/src/app/Api/Admin/Dtos/BannerDtos.cs
@@ -4,6 +4,10 @@ namespace app.Api.Admin.Dtos;
 
 public record BannerResponse(
     Guid Id,
+    string? TitleEn,
+    string? TitleFr,
+    string? SubtitleEn,
+    string? SubtitleFr,
     string MessageEn,
     string MessageFr,
     BannerVariant Variant,
@@ -18,6 +22,10 @@ public record BannerResponse(
     DateTime CreatedAt);
 
 public record CreateOrUpdateBannerRequest(
+    string? TitleEn,
+    string? TitleFr,
+    string? SubtitleEn,
+    string? SubtitleFr,
     string MessageEn,
     string MessageFr,
     BannerVariant Variant,

--- a/src/app/Api/Admin/Dtos/BannerDtos.cs
+++ b/src/app/Api/Admin/Dtos/BannerDtos.cs
@@ -1,0 +1,31 @@
+using app.domain.Models.BannerAggregate.Enums;
+
+namespace app.Api.Admin.Dtos;
+
+public record BannerResponse(
+    Guid Id,
+    string MessageEn,
+    string MessageFr,
+    BannerVariant Variant,
+    DateTime StartDate,
+    DateTime EndDate,
+    string? Link,
+    string? LinkLabelEn,
+    string? LinkLabelFr,
+    bool Dismissible,
+    int Priority,
+    bool IsEnabled,
+    DateTime CreatedAt);
+
+public record CreateOrUpdateBannerRequest(
+    string MessageEn,
+    string MessageFr,
+    BannerVariant Variant,
+    DateTime StartDate,
+    DateTime EndDate,
+    string? Link,
+    string? LinkLabelEn,
+    string? LinkLabelFr,
+    bool Dismissible,
+    int Priority,
+    bool IsEnabled);

--- a/src/app/Components/Components/BannerStack.razor
+++ b/src/app/Components/Components/BannerStack.razor
@@ -5,32 +5,48 @@
 
 @if (_banners.Length > 0)
 {
-    <div id="banner-stack" class="w-full flex flex-col">
+    <div id="banner-stack" class="w-full flex flex-col shadow-lg shadow-black/5">
         @foreach (var banner in _banners)
         {
             var textColor = VariantTextClass(banner.Variant);
-            <div class="banner @VariantBgClass(banner.Variant) @textColor flex items-center gap-3 px-4 py-2.5 text-sm"
+            var ctaClass = VariantCtaClass(banner.Variant);
+            var isLight = IsLightBanner(banner.Variant);
+            <div class="banner @VariantBgClass(banner.Variant) @textColor relative overflow-hidden"
                  data-banner-id="@banner.Id"
                  data-banner-dismissible="@(banner.Dismissible.ToString().ToLowerInvariant())">
-                <i class="@VariantIcon(banner.Variant) @textColor text-base shrink-0"></i>
-                <div class="flex-1 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-center">
-                    <span class="@textColor">@Message(banner)</span>
-                    @if (!string.IsNullOrWhiteSpace(banner.Link))
+                <div class="pointer-events-none absolute inset-0 opacity-40">
+                    <div class="absolute -top-16 -right-16 w-56 h-56 rounded-full @(isLight ? "bg-white/40" : "bg-white/15") blur-3xl"></div>
+                    <div class="absolute -bottom-16 left-1/3 w-48 h-48 rounded-full @(isLight ? "bg-white/30" : "bg-white/10") blur-3xl"></div>
+                </div>
+                @if (banner.Variant == BannerVariant.Advertisement)
+                {
+                    <div class="banner-shine pointer-events-none absolute inset-0"></div>
+                }
+                <div class="relative max-w-7xl mx-auto flex items-center gap-3 px-4 sm:px-6 py-2.5 sm:py-3">
+                    <span class="@VariantBadgeClass(banner.Variant) inline-flex shrink-0 items-center justify-center size-8 rounded-full ring-1 backdrop-blur-sm">
+                        <i class="@VariantIcon(banner.Variant) @textColor text-[15px]"></i>
+                    </span>
+                    <div class="flex-1 flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-center">
+                        <span class="@textColor text-[13px] sm:text-sm font-medium tracking-tight leading-snug">
+                            @Message(banner)
+                        </span>
+                        @if (!string.IsNullOrWhiteSpace(banner.Link))
+                        {
+                            <a href="@banner.Link" target="_blank" rel="noreferrer"
+                               class="@ctaClass @textColor inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[11px] sm:text-xs font-semibold uppercase tracking-wider transition-all">
+                                @(LinkLabel(banner) ?? "Learn more")
+                                <i class="ph ph-arrow-up-right @textColor text-[11px]"></i>
+                            </a>
+                        }
+                    </div>
+                    @if (banner.Dismissible)
                     {
-                        <a href="@banner.Link" target="_blank" rel="noreferrer"
-                           class="@textColor font-medium underline hover:no-underline whitespace-nowrap">
-                            @(LinkLabel(banner) ?? "Learn more")
-                            <i class="ph ph-arrow-up-right @textColor text-xs"></i>
-                        </a>
+                        <button type="button" class="banner-dismiss shrink-0 rounded-full p-1.5 @(isLight ? "hover:bg-black/10" : "hover:bg-white/15") opacity-70 hover:opacity-100 transition-all cursor-pointer"
+                                aria-label="Dismiss">
+                            <i class="ph ph-x @textColor text-sm"></i>
+                        </button>
                     }
                 </div>
-                @if (banner.Dismissible)
-                {
-                    <button type="button" class="banner-dismiss shrink-0 rounded-full p-1 hover:bg-black/10 transition-colors cursor-pointer"
-                            aria-label="Dismiss">
-                        <i class="ph ph-x @textColor text-base"></i>
-                    </button>
-                }
             </div>
         }
     </div>
@@ -56,11 +72,11 @@
 
     private static string VariantBgClass(BannerVariant v) => v switch
     {
-        BannerVariant.Announcement => "bg-secondary",
-        BannerVariant.Advertisement => "bg-tertiary",
-        BannerVariant.Promo => "bg-primary",
-        BannerVariant.Event => "bg-dark-purple",
-        BannerVariant.Maintenance => "bg-amber-500",
+        BannerVariant.Announcement => "bg-gradient-to-r from-secondary via-secondary-accentuation to-secondary",
+        BannerVariant.Advertisement => "bg-gradient-to-r from-tertiary via-tertiary-accentuation to-tertiary",
+        BannerVariant.Promo => "bg-gradient-to-r from-primary via-primary-accentuation to-primary",
+        BannerVariant.Event => "bg-gradient-to-r from-dark-purple via-secondary to-dark-purple",
+        BannerVariant.Maintenance => "bg-gradient-to-r from-amber-400 via-amber-500 to-amber-400",
         _ => "bg-secondary",
     };
 
@@ -73,6 +89,17 @@
         BannerVariant.Maintenance => "text-dark-purple",
         _ => "text-white",
     };
+
+    private static string VariantCtaClass(BannerVariant v) => IsLightBanner(v)
+        ? "bg-dark-purple/10 hover:bg-dark-purple/20"
+        : "bg-white/15 hover:bg-white/25 backdrop-blur-sm";
+
+    private static string VariantBadgeClass(BannerVariant v) => IsLightBanner(v)
+        ? "bg-dark-purple/10 ring-dark-purple/15"
+        : "bg-white/15 ring-white/25";
+
+    private static bool IsLightBanner(BannerVariant v) =>
+        v == BannerVariant.Advertisement || v == BannerVariant.Maintenance;
 
     private static string VariantIcon(BannerVariant v) => v switch
     {

--- a/src/app/Components/Components/BannerStack.razor
+++ b/src/app/Components/Components/BannerStack.razor
@@ -11,42 +11,93 @@
             var textColor = VariantTextClass(banner.Variant);
             var ctaClass = VariantCtaClass(banner.Variant);
             var isLight = IsLightBanner(banner.Variant);
+            var title = Title(banner);
+            var subtitle = Subtitle(banner);
+            var hasTitle = !string.IsNullOrWhiteSpace(title);
             <div class="banner @VariantBgClass(banner.Variant) @textColor relative overflow-hidden"
                  data-banner-id="@banner.Id"
                  data-banner-dismissible="@(banner.Dismissible.ToString().ToLowerInvariant())">
                 <div class="pointer-events-none absolute inset-0 opacity-40">
-                    <div class="absolute -top-16 -right-16 w-56 h-56 rounded-full @(isLight ? "bg-white/40" : "bg-white/15") blur-3xl"></div>
-                    <div class="absolute -bottom-16 left-1/3 w-48 h-48 rounded-full @(isLight ? "bg-white/30" : "bg-white/10") blur-3xl"></div>
+                    <div class="absolute -top-20 -right-20 w-72 h-72 rounded-full @(isLight ? "bg-white/40" : "bg-white/15") blur-3xl"></div>
+                    <div class="absolute -bottom-20 left-1/4 w-56 h-56 rounded-full @(isLight ? "bg-white/30" : "bg-white/10") blur-3xl"></div>
+                    <div class="absolute top-1/2 -translate-y-1/2 left-[55%] w-44 h-44 rounded-full @(isLight ? "bg-white/20" : "bg-white/8") blur-2xl"></div>
                 </div>
                 @if (banner.Variant == BannerVariant.Advertisement)
                 {
                     <div class="banner-shine pointer-events-none absolute inset-0"></div>
                 }
-                <div class="relative max-w-7xl mx-auto flex items-center gap-3 px-4 sm:px-6 py-2.5 sm:py-3">
-                    <span class="@VariantBadgeClass(banner.Variant) inline-flex shrink-0 items-center justify-center size-8 rounded-full ring-1 backdrop-blur-sm">
-                        <i class="@VariantIcon(banner.Variant) @textColor text-[15px]"></i>
-                    </span>
-                    <div class="flex-1 flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-center">
-                        <span class="@textColor text-[13px] sm:text-sm font-medium tracking-tight leading-snug">
+                @if (hasTitle)
+                {
+                    @* Rich layout: title + subtitle | message | CTA | dismiss *@
+                    <div class="relative max-w-7xl mx-auto flex flex-col md:flex-row md:items-center gap-4 md:gap-8 px-5 md:px-8 py-4 md:py-5">
+                        <div class="flex items-start gap-3 md:gap-4 md:min-w-[200px]">
+                            <span class="@VariantBadgeClass(banner.Variant) inline-flex shrink-0 items-center justify-center size-10 rounded-xl ring-1 backdrop-blur-sm mt-0.5">
+                                <i class="@VariantIcon(banner.Variant) @textColor text-lg"></i>
+                            </span>
+                            <div class="flex flex-col">
+                                <span class="@textColor font-heading font-bold text-lg md:text-xl leading-tight tracking-tight">
+                                    @title
+                                </span>
+                                @if (!string.IsNullOrWhiteSpace(subtitle))
+                                {
+                                    <span class="@textColor text-[11px] md:text-xs font-medium opacity-80 mt-0.5 uppercase tracking-widest">
+                                        @subtitle
+                                    </span>
+                                }
+                            </div>
+                        </div>
+                        <div class="flex-1 @textColor text-sm md:text-[15px] leading-snug">
                             @Message(banner)
+                        </div>
+                        <div class="flex items-center gap-2 shrink-0">
+                            @if (!string.IsNullOrWhiteSpace(banner.Link))
+                            {
+                                <a href="@banner.Link" target="_blank" rel="noreferrer"
+                                   class="@VariantPrimaryCtaClass(banner.Variant) inline-flex items-center gap-2 px-4 py-2 rounded-full text-sm font-semibold transition-all shadow-sm hover:shadow-md whitespace-nowrap">
+                                    @(LinkLabel(banner) ?? "Learn more")
+                                    <i class="ph ph-arrow-right text-sm"></i>
+                                </a>
+                            }
+                            @if (banner.Dismissible)
+                            {
+                                <button type="button"
+                                        class="banner-dismiss shrink-0 rounded-full p-2 @(isLight ? "hover:bg-black/10" : "hover:bg-white/15") opacity-70 hover:opacity-100 transition-all cursor-pointer"
+                                        aria-label="Dismiss">
+                                    <i class="ph ph-x @textColor text-sm"></i>
+                                </button>
+                            }
+                        </div>
+                    </div>
+                }
+                else
+                {
+                    @* Compact layout: icon | message | pill CTA | dismiss *@
+                    <div class="relative max-w-7xl mx-auto flex items-center gap-3 px-4 sm:px-6 py-2.5 sm:py-3">
+                        <span class="@VariantBadgeClass(banner.Variant) inline-flex shrink-0 items-center justify-center size-8 rounded-full ring-1 backdrop-blur-sm">
+                            <i class="@VariantIcon(banner.Variant) @textColor text-[15px]"></i>
                         </span>
-                        @if (!string.IsNullOrWhiteSpace(banner.Link))
+                        <div class="flex-1 flex flex-wrap items-center justify-center gap-x-3 gap-y-2 text-center">
+                            <span class="@textColor text-[13px] sm:text-sm font-medium tracking-tight leading-snug">
+                                @Message(banner)
+                            </span>
+                            @if (!string.IsNullOrWhiteSpace(banner.Link))
+                            {
+                                <a href="@banner.Link" target="_blank" rel="noreferrer"
+                                   class="@ctaClass @textColor inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[11px] sm:text-xs font-semibold uppercase tracking-wider transition-all">
+                                    @(LinkLabel(banner) ?? "Learn more")
+                                    <i class="ph ph-arrow-up-right @textColor text-[11px]"></i>
+                                </a>
+                            }
+                        </div>
+                        @if (banner.Dismissible)
                         {
-                            <a href="@banner.Link" target="_blank" rel="noreferrer"
-                               class="@ctaClass @textColor inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-[11px] sm:text-xs font-semibold uppercase tracking-wider transition-all">
-                                @(LinkLabel(banner) ?? "Learn more")
-                                <i class="ph ph-arrow-up-right @textColor text-[11px]"></i>
-                            </a>
+                            <button type="button" class="banner-dismiss shrink-0 rounded-full p-1.5 @(isLight ? "hover:bg-black/10" : "hover:bg-white/15") opacity-70 hover:opacity-100 transition-all cursor-pointer"
+                                    aria-label="Dismiss">
+                                <i class="ph ph-x @textColor text-sm"></i>
+                            </button>
                         }
                     </div>
-                    @if (banner.Dismissible)
-                    {
-                        <button type="button" class="banner-dismiss shrink-0 rounded-full p-1.5 @(isLight ? "hover:bg-black/10" : "hover:bg-white/15") opacity-70 hover:opacity-100 transition-all cursor-pointer"
-                                aria-label="Dismiss">
-                            <i class="ph ph-x @textColor text-sm"></i>
-                        </button>
-                    }
-                </div>
+                }
             </div>
         }
     </div>
@@ -60,15 +111,16 @@
         _banners = await BannerService.GetActiveAsync();
     }
 
-    private static string Message(BannerEntity b) =>
-        System.Globalization.CultureInfo.CurrentCulture.Name == "fr-FR"
-            ? b.MessageFr
-            : b.MessageEn;
+    private static bool IsFrench =>
+        System.Globalization.CultureInfo.CurrentCulture.Name == "fr-FR";
 
-    private static string? LinkLabel(BannerEntity b) =>
-        System.Globalization.CultureInfo.CurrentCulture.Name == "fr-FR"
-            ? b.LinkLabelFr
-            : b.LinkLabelEn;
+    private static string? Title(BannerEntity b) => IsFrench ? b.TitleFr : b.TitleEn;
+
+    private static string? Subtitle(BannerEntity b) => IsFrench ? b.SubtitleFr : b.SubtitleEn;
+
+    private static string Message(BannerEntity b) => IsFrench ? b.MessageFr : b.MessageEn;
+
+    private static string? LinkLabel(BannerEntity b) => IsFrench ? b.LinkLabelFr : b.LinkLabelEn;
 
     private static string VariantBgClass(BannerVariant v) => v switch
     {
@@ -93,6 +145,10 @@
     private static string VariantCtaClass(BannerVariant v) => IsLightBanner(v)
         ? "bg-dark-purple/10 hover:bg-dark-purple/20"
         : "bg-white/15 hover:bg-white/25 backdrop-blur-sm";
+
+    private static string VariantPrimaryCtaClass(BannerVariant v) => IsLightBanner(v)
+        ? "bg-dark-purple text-white hover:bg-dark-purple/90"
+        : "bg-white text-dark-purple hover:bg-white/90";
 
     private static string VariantBadgeClass(BannerVariant v) => IsLightBanner(v)
         ? "bg-dark-purple/10 ring-dark-purple/15"

--- a/src/app/Components/Components/BannerStack.razor
+++ b/src/app/Components/Components/BannerStack.razor
@@ -1,0 +1,86 @@
+@using app.business.Services
+@using app.domain.Models.BannerAggregate.Enums
+@using BannerEntity = app.domain.Models.BannerAggregate.Banner
+@inject IBannerService BannerService
+
+@if (_banners.Length > 0)
+{
+    <div id="banner-stack" class="w-full flex flex-col">
+        @foreach (var banner in _banners)
+        {
+            var textColor = VariantTextClass(banner.Variant);
+            <div class="banner @VariantBgClass(banner.Variant) @textColor flex items-center gap-3 px-4 py-2.5 text-sm"
+                 data-banner-id="@banner.Id"
+                 data-banner-dismissible="@(banner.Dismissible.ToString().ToLowerInvariant())">
+                <i class="@VariantIcon(banner.Variant) @textColor text-base shrink-0"></i>
+                <div class="flex-1 flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-center">
+                    <span class="@textColor">@Message(banner)</span>
+                    @if (!string.IsNullOrWhiteSpace(banner.Link))
+                    {
+                        <a href="@banner.Link" target="_blank" rel="noreferrer"
+                           class="@textColor font-medium underline hover:no-underline whitespace-nowrap">
+                            @(LinkLabel(banner) ?? "Learn more")
+                            <i class="ph ph-arrow-up-right @textColor text-xs"></i>
+                        </a>
+                    }
+                </div>
+                @if (banner.Dismissible)
+                {
+                    <button type="button" class="banner-dismiss shrink-0 rounded-full p-1 hover:bg-black/10 transition-colors cursor-pointer"
+                            aria-label="Dismiss">
+                        <i class="ph ph-x @textColor text-base"></i>
+                    </button>
+                }
+            </div>
+        }
+    </div>
+}
+
+@code {
+    private BannerEntity[] _banners = [];
+
+    protected override async Task OnInitializedAsync()
+    {
+        _banners = await BannerService.GetActiveAsync();
+    }
+
+    private static string Message(BannerEntity b) =>
+        System.Globalization.CultureInfo.CurrentCulture.Name == "fr-FR"
+            ? b.MessageFr
+            : b.MessageEn;
+
+    private static string? LinkLabel(BannerEntity b) =>
+        System.Globalization.CultureInfo.CurrentCulture.Name == "fr-FR"
+            ? b.LinkLabelFr
+            : b.LinkLabelEn;
+
+    private static string VariantBgClass(BannerVariant v) => v switch
+    {
+        BannerVariant.Announcement => "bg-secondary",
+        BannerVariant.Advertisement => "bg-tertiary",
+        BannerVariant.Promo => "bg-primary",
+        BannerVariant.Event => "bg-dark-purple",
+        BannerVariant.Maintenance => "bg-amber-500",
+        _ => "bg-secondary",
+    };
+
+    private static string VariantTextClass(BannerVariant v) => v switch
+    {
+        BannerVariant.Announcement => "text-white",
+        BannerVariant.Advertisement => "text-dark-purple",
+        BannerVariant.Promo => "text-white",
+        BannerVariant.Event => "text-white",
+        BannerVariant.Maintenance => "text-dark-purple",
+        _ => "text-white",
+    };
+
+    private static string VariantIcon(BannerVariant v) => v switch
+    {
+        BannerVariant.Announcement => "ph-fill ph-megaphone",
+        BannerVariant.Advertisement => "ph-fill ph-sparkle",
+        BannerVariant.Promo => "ph-fill ph-tag",
+        BannerVariant.Event => "ph-fill ph-calendar-star",
+        BannerVariant.Maintenance => "ph-fill ph-wrench",
+        _ => "ph-fill ph-megaphone",
+    };
+}

--- a/src/app/Components/Layout/MainLayout.razor
+++ b/src/app/Components/Layout/MainLayout.razor
@@ -1,4 +1,5 @@
 ﻿@inherits LayoutComponentBase
+<BannerStack />
 <main>
     @Body
     <BackToTop />

--- a/src/app/Extensions/Extensions.cs
+++ b/src/app/Extensions/Extensions.cs
@@ -67,6 +67,7 @@ public static class Extensions
         services.AddScoped<IFileUploader, FileUploader>();
         services.AddScoped<IFileManager, FileManager>();
         services.AddScoped<IEventService, EventService>();
+        services.AddScoped<IBannerService, BannerService>();
         services.AddScoped<ITokenProvider, TokenProvider>();
         services.AddScoped<IProjectService, ProjectService>();
         services.AddScoped<IFileDownloader, FileDownloader>();

--- a/src/app/styles/input.css
+++ b/src/app/styles/input.css
@@ -443,3 +443,46 @@
 .tabs .tab.active{
   @apply text-secondary border-b-2 border-secondary hover:border-secondary-accentuation hover:text-secondary-accentuation;
 }
+
+/* Banners */
+.banner {
+  animation: banner-slide-down 360ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.banner + .banner {
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+@keyframes banner-slide-down {
+  from {
+    transform: translateY(-12px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.banner-shine::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    115deg,
+    transparent 30%,
+    rgba(255, 255, 255, 0.55) 50%,
+    transparent 70%
+  );
+  transform: translateX(-100%);
+  animation: banner-shine 4.5s ease-in-out 1s infinite;
+}
+
+@keyframes banner-shine {
+  0% {
+    transform: translateX(-100%);
+  }
+  60%, 100% {
+    transform: translateX(100%);
+  }
+}

--- a/src/app/styles/input.css
+++ b/src/app/styles/input.css
@@ -209,6 +209,10 @@
 
 #navbar.scrolled {
   position: fixed;
+  top: var(--banner-stack-height, 0px);
+  left: 0;
+  right: 0;
+  z-index: 50;
   animation-name: expand-nav;
   animation-duration: .3s;
   overflow: visible;
@@ -217,12 +221,12 @@
 
 @keyframes expand-nav {
   from {
-    top: -100%;
+    transform: translateY(-100%);
     opacity: 0;
   }
 
   to {
-    top: 0;
+    transform: translateY(0);
     opacity: 1;
   }
 }
@@ -445,6 +449,26 @@
 }
 
 /* Banners */
+#banner-stack.scrolled {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 51;
+  animation: banner-stack-pin .3s;
+}
+
+@keyframes banner-stack-pin {
+  from {
+    transform: translateY(-100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
 .banner {
   animation: banner-slide-down 360ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }

--- a/src/app/wwwroot/js/app.js
+++ b/src/app/wwwroot/js/app.js
@@ -45,6 +45,44 @@ function backToTop() {
   window.scrollTo({ top: 0, behavior: "smooth" });
 }
 
+(function initBanners() {
+  const STORAGE_KEY = "dismissed-banners";
+  function dismissed() {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY) || "[]");
+    } catch {
+      return [];
+    }
+  }
+  function remember(id) {
+    const list = dismissed();
+    if (!list.includes(id)) list.push(id);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  }
+  function apply() {
+    const stack = document.getElementById("banner-stack");
+    if (!stack) return;
+    const ids = dismissed();
+    stack.querySelectorAll("[data-banner-id]").forEach((el) => {
+      const id = el.getAttribute("data-banner-id");
+      if (ids.includes(id)) el.remove();
+    });
+    stack.querySelectorAll(".banner-dismiss").forEach((btn) => {
+      btn.addEventListener("click", (e) => {
+        const banner = e.currentTarget.closest("[data-banner-id]");
+        if (!banner) return;
+        remember(banner.getAttribute("data-banner-id"));
+        banner.remove();
+      });
+    });
+  }
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", apply);
+  } else {
+    apply();
+  }
+})();
+
 function showDotnetSessions() {
   const dotnet = document.getElementById("dotnet-sessions");
   const microsoft = document.getElementById("microsoft-sessions");

--- a/src/app/wwwroot/js/app.js
+++ b/src/app/wwwroot/js/app.js
@@ -21,11 +21,22 @@ window.addEventListener("scroll", (e) => {
 
 function collapseNavbar() {
   const navbar = document.getElementById("navbar");
+  const bannerStack = document.getElementById("banner-stack");
+  if (bannerStack) bannerStack.classList.remove("scrolled");
+  document.documentElement.style.setProperty("--banner-stack-height", "0px");
   navbar.classList.remove("scrolled");
 }
 
 function expandNavbar() {
   const navbar = document.getElementById("navbar");
+  const bannerStack = document.getElementById("banner-stack");
+  if (bannerStack) {
+    document.documentElement.style.setProperty(
+      "--banner-stack-height",
+      `${bannerStack.offsetHeight}px`,
+    );
+    bannerStack.classList.add("scrolled");
+  }
   navbar.classList.remove("scrolled");
   navbar.classList.add("scrolled");
 }


### PR DESCRIPTION
## Summary
- New **Banner** aggregate (`MessageEn/Fr`, optional `TitleEn/Fr` + `SubtitleEn/Fr`, `Variant`, `StartDate`/`EndDate`, optional CTA link, `Dismissible`, `Priority`, `IsEnabled`) with full CRUD through the admin panel.
- Public site renders all **currently-active** banners stacked at the top of `MainLayout`. Two layouts: a rich Microsoft-style headline + subtitle + body + pill CTA when a title is set, and a compact centered single-line layout when it isn't.
- 5 intent-based variants — Announcement, Advertisement, Promo, Event, Maintenance — each with its own gradient, icon, and contrast-aware text/CTA colors. Advertisement variant gets a subtle shine sweep.
- Banner stack **pins to the top on scroll** with the same threshold and slide-in animation as the navbar. A `--banner-stack-height` CSS custom property is computed at scroll time so the navbar slides in cleanly below the pinned banner instead of overlapping.
- Banners flagged as dismissible can be closed by visitors; the dismissal is remembered in `localStorage` (`dismissed-banners`).
- Active banners list is cached in memory for 5 minutes and invalidated on any write.

## Architecture
- **Domain**: `app.domain/Models/BannerAggregate/Banner.cs` + `BannerVariant` enum + `BannerModel` view-model.
- **Business**: `IBannerService` with `GetAllAsync` (paged), `GetAsync`, `GetActiveAsync`, `CreateAsync`, `UpdateAsync`, `DeleteAsync`.
- **Infrastructure**: `BannerService` (validates `EndDate > StartDate`, manages cache), `BannerConfigurations` (indexed on `IsEnabled, StartDate, EndDate`), two EF migrations.
- **API**: `AdminBannersApi` mounted at `/api/admin/banners` (cookie auth, admin role).
- **Public UI**: `BannerStack.razor` injected at the top of `MainLayout.razor` + JS dismiss handler in `wwwroot/js/app.js`.
- **Admin React**: route group `/admin/banners` (index / new / `\$id.edit`), `BannerForm`, `api/banners.ts`, sidebar entry.

## Test plan
- [ ] Apply the migration: `dotnet ef database update --project src/app.infrastructure --startup-project src/app --context AppDbContext`
- [ ] Create a banner in the admin panel without a title — verify compact centered layout renders
- [ ] Create a banner with a title + subtitle (e.g. "AI Skills Fest" / "June 8-12, 2026") — verify rich layout with bold title, uppercase subtitle, solid pill CTA
- [ ] Verify all five variants render with correct gradient, icon, and contrasting text/CTA colors
- [ ] Verify only banners where `now ∈ [StartDate, EndDate]` and `IsEnabled = true` appear on the public site
- [ ] Verify `Priority` (desc) controls stack order
- [ ] Dismiss a dismissible banner — verify it stays hidden on next page load (cleared via `localStorage.removeItem('dismissed-banners')`)
- [ ] Scroll past the navbar threshold — banner stack and navbar both pin to top; navbar sits directly under the banner with no overlap
- [ ] Scroll back up — both unpin together
- [ ] Switch language to French — banner content swaps to `MessageFr` / `TitleFr` / `SubtitleFr` / `LinkLabelFr`
- [ ] Verify the cached active-banners list refreshes within 5 min of any create/update/delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)