### PR TITLE
Inject prod config at runtime instead of baking into the image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,58 @@
-# SQL Server
+# =========================================================================
+# Production environment file. Copy to `.env` and fill in real values.
+# Consumed by docker-compose.prod.yml.
+#
+# In CI the deploy workflow writes this file on the VPS from GitHub Secrets
+# (see .github/workflows/main_deploy.yml). Variable names below match the
+# Secret names so the workflow does no renaming.
+# =========================================================================
+
+# --- App ----------------------------------------------------------------
+APP_PORT=5000
+
+# --- SQL Server container init ------------------------------------------
 MSSQL_SA_PASSWORD=your-strong-password-here
 MSSQL_PID=Evaluation
 MSSQL_PORT=1433
 
-# MinIO
+# --- MinIO container init -----------------------------------------------
 MINIO_ROOT_USER=minioadmin
 MINIO_ROOT_PASSWORD=your-minio-password-here
 MINIO_API_PORT=9000
 MINIO_CONSOLE_PORT=9001
 
-# App
-APP_PORT=5000
+# --- .NET connection strings (consumed by the app) ----------------------
+# Full SQL Server connection string (server, db, user, password, etc.).
+AZURE_SQLSERVER_WEBSITE_DATABASE=Server=sqlserver,1433;Database=Website;User Id=sa;Password=your-strong-password-here;TrustServerCertificate=True;Encrypt=false
+# Optional; leave empty if Postgres is not used.
+AZURE_POSTGRES_WEBSITE_DATABASE=
+# Sqlite path for the projects-cache DB. Defaults to /app/data/projects.db if blank.
+SQLITE_CONNECTION=Data Source=/app/data/projects.db;
+
+# --- Cookie auth --------------------------------------------------------
+COOKIES_ISSUER=dotnet.cm
+COOKIES_LOGINPATH=/login
+COOKIES_LOGOUTPATH=/logout
+COOKIES_ACCESSDENIEDPATH=/access-denied
+COOKIES_EXPIRATIONINDAYS=30
+
+# --- JWT (external API auth) --------------------------------------------
+JWT_ISSUER=DotnetCameroon
+JWT_AUDIENCE=DotnetCameroon
+# REQUIRED. Generate with `openssl rand -base64 64`.
+JWT_SECRET=replace-me-with-a-long-random-secret
+JWT_EXPIRATION_IN_MINUTES=60
+
+# --- MinIO (app-side, what the .NET app uses to talk to MinIO) ----------
+# In-network endpoint the app uses. Defaults to minio:9000 if blank.
+MINIO_ENDPOINT=minio:9000
+# Externally reachable host:port for signed URLs (what end users see).
+MINIO_PUBLICENDPOINT=files.dotnet.cm
+# These should match the MINIO_ROOT_* values above on a self-hosted setup.
+MINIO_ACCESSKEY=minioadmin
+MINIO_SECRETKEY=your-minio-password-here
+MINIO_BUCKETNAME=uploads
+
+# --- Observability (optional) -------------------------------------------
+AZURE_APPINSIGHTS_INSTRUMENTAL_KEY=
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:18889

--- a/.github/workflows/main_deploy.yml
+++ b/.github/workflows/main_deploy.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "src/**"
+      - "docker-compose.prod.yml"
       - ".github/workflows/main_deploy.yml"
 
 concurrency:
@@ -25,50 +26,83 @@ jobs:
       - name: Generate CSS
         run: npm install && npm run tailwind
 
-      - name: App Settings Variable Substitution
-        uses: microsoft/variable-substitution@v1
-        with:
-          files: './src/app/appsettings.Production.json'
-        env:
-          ConnectionStrings.SqlServer: ${{ secrets.AZURE_SQLSERVER_WEBSITE_DATABASE }}
-          ConnectionStrings.Npgsql: ${{ secrets.AZURE_POSTGRES_WEBSITE_DATABASE }}
-          ConnectionStrings.Sqlite: ${{ secrets.SQLITE_CONNECTION }}
-          CookiesOptions.Issuer: ${{ secrets.COOKIES_ISSUER}}
-          CookiesOptions.LoginPath: ${{ secrets.COOKIES_LOGINPATH}}
-          CookiesOptions.LogoutPath: ${{ secrets.COOKIES_LOGOUTPATH}}
-          CookiesOptions.AccessDeniedPath: ${{ secrets.COOKIES_ACCESSDENIEDPATH}}
-          CookiesOptions.ExpirationInDays: ${{ secrets.COOKIES_EXPIRATIONINDAYS}}
-          JwtOptions.Issuer: ${{ secrets.JWT_ISSUER}}
-          JwtOptions.Audience: ${{ secrets.JWT_AUDIENCE}}
-          JwtOptions.Secret: ${{ secrets.JWT_SECRET}}
-          JwtOptions.ExpirationInMinutes: ${{ secrets.JWT_EXPIRATION_IN_MINUTES}}
-          ApplicationInsights.InstrumentationKey: ${{ secrets.AZURE_APPINSIGHTS_INSTRUMENTAL_KEY}}
-          Minio.Endpoint: ${{ secrets.MINIO_ENDPOINT}}
-          Minio.PublicEndpoint: ${{ secrets.MINIO_PUBLICENDPOINT}}
-          Minio.AccessKey: ${{ secrets.MINIO_ACCESSKEY}}
-          Minio.SecretKey: ${{ secrets.MINIO_SECRETKEY}}
-          Minio.BucketName: ${{ secrets.MINIO_BUCKETNAME}}
-
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Docker images
+      - name: Build and push Docker image
         run: |
           docker build -t djoufson/dotnetcameroon -f ./src/app/Dockerfile .
           docker push djoufson/dotnetcameroon:latest
 
       - name: Deploy to VPS
         uses: appleboy/ssh-action@master
+        env:
+          # --- VPS / Docker Hub access ---
+          PROJECT_PATH: ${{ secrets.PROJECT_PATH }}
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          # --- .NET runtime config (consumed by docker-compose.prod.yml) ---
+          AZURE_SQLSERVER_WEBSITE_DATABASE: ${{ secrets.AZURE_SQLSERVER_WEBSITE_DATABASE }}
+          AZURE_POSTGRES_WEBSITE_DATABASE: ${{ secrets.AZURE_POSTGRES_WEBSITE_DATABASE }}
+          SQLITE_CONNECTION: ${{ secrets.SQLITE_CONNECTION }}
+          COOKIES_ISSUER: ${{ secrets.COOKIES_ISSUER }}
+          COOKIES_LOGINPATH: ${{ secrets.COOKIES_LOGINPATH }}
+          COOKIES_LOGOUTPATH: ${{ secrets.COOKIES_LOGOUTPATH }}
+          COOKIES_ACCESSDENIEDPATH: ${{ secrets.COOKIES_ACCESSDENIEDPATH }}
+          COOKIES_EXPIRATIONINDAYS: ${{ secrets.COOKIES_EXPIRATIONINDAYS }}
+          JWT_ISSUER: ${{ secrets.JWT_ISSUER }}
+          JWT_AUDIENCE: ${{ secrets.JWT_AUDIENCE }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          JWT_EXPIRATION_IN_MINUTES: ${{ secrets.JWT_EXPIRATION_IN_MINUTES }}
+          AZURE_APPINSIGHTS_INSTRUMENTAL_KEY: ${{ secrets.AZURE_APPINSIGHTS_INSTRUMENTAL_KEY }}
+          MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+          MINIO_PUBLICENDPOINT: ${{ secrets.MINIO_PUBLICENDPOINT }}
+          MINIO_ACCESSKEY: ${{ secrets.MINIO_ACCESSKEY }}
+          MINIO_SECRETKEY: ${{ secrets.MINIO_SECRETKEY }}
+          MINIO_BUCKETNAME: ${{ secrets.MINIO_BUCKETNAME }}
+          # --- Container init secrets (must exist as GitHub Secrets) ---
+          MSSQL_SA_PASSWORD: ${{ secrets.MSSQL_SA_PASSWORD }}
+          MINIO_ROOT_USER: ${{ secrets.MINIO_ROOT_USER }}
+          MINIO_ROOT_PASSWORD: ${{ secrets.MINIO_ROOT_PASSWORD }}
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USERNAME }}
           key: ${{ secrets.VPS_SSH_KEY }}
           port: ${{ secrets.VPS_PORT }}
+          envs: PROJECT_PATH,DOCKERHUB_USERNAME,DOCKERHUB_TOKEN,AZURE_SQLSERVER_WEBSITE_DATABASE,AZURE_POSTGRES_WEBSITE_DATABASE,SQLITE_CONNECTION,COOKIES_ISSUER,COOKIES_LOGINPATH,COOKIES_LOGOUTPATH,COOKIES_ACCESSDENIEDPATH,COOKIES_EXPIRATIONINDAYS,JWT_ISSUER,JWT_AUDIENCE,JWT_SECRET,JWT_EXPIRATION_IN_MINUTES,AZURE_APPINSIGHTS_INSTRUMENTAL_KEY,MINIO_ENDPOINT,MINIO_PUBLICENDPOINT,MINIO_ACCESSKEY,MINIO_SECRETKEY,MINIO_BUCKETNAME,MSSQL_SA_PASSWORD,MINIO_ROOT_USER,MINIO_ROOT_PASSWORD
           script: |
-            cd ${{ secrets.PROJECT_PATH }}
-            docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
+            set -e
+            cd "$PROJECT_PATH"
+            umask 077
+            cat > .env <<ENV_EOF
+            # Written by GitHub Actions main_deploy.yml. Do not edit by hand;
+            # re-run the deploy workflow to refresh. Non-sensitive defaults
+            # (ports, MSSQL_PID, etc.) come from docker-compose.prod.yml fallbacks.
+            MSSQL_SA_PASSWORD=${MSSQL_SA_PASSWORD}
+            MINIO_ROOT_USER=${MINIO_ROOT_USER}
+            MINIO_ROOT_PASSWORD=${MINIO_ROOT_PASSWORD}
+            AZURE_SQLSERVER_WEBSITE_DATABASE=${AZURE_SQLSERVER_WEBSITE_DATABASE}
+            AZURE_POSTGRES_WEBSITE_DATABASE=${AZURE_POSTGRES_WEBSITE_DATABASE}
+            SQLITE_CONNECTION=${SQLITE_CONNECTION}
+            COOKIES_ISSUER=${COOKIES_ISSUER}
+            COOKIES_LOGINPATH=${COOKIES_LOGINPATH}
+            COOKIES_LOGOUTPATH=${COOKIES_LOGOUTPATH}
+            COOKIES_ACCESSDENIEDPATH=${COOKIES_ACCESSDENIEDPATH}
+            COOKIES_EXPIRATIONINDAYS=${COOKIES_EXPIRATIONINDAYS}
+            JWT_ISSUER=${JWT_ISSUER}
+            JWT_AUDIENCE=${JWT_AUDIENCE}
+            JWT_SECRET=${JWT_SECRET}
+            JWT_EXPIRATION_IN_MINUTES=${JWT_EXPIRATION_IN_MINUTES}
+            AZURE_APPINSIGHTS_INSTRUMENTAL_KEY=${AZURE_APPINSIGHTS_INSTRUMENTAL_KEY}
+            MINIO_ENDPOINT=${MINIO_ENDPOINT}
+            MINIO_PUBLICENDPOINT=${MINIO_PUBLICENDPOINT}
+            MINIO_ACCESSKEY=${MINIO_ACCESSKEY}
+            MINIO_SECRETKEY=${MINIO_SECRETKEY}
+            MINIO_BUCKETNAME=${MINIO_BUCKETNAME}
+            ENV_EOF
+            docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_TOKEN"
             docker compose -f docker-compose.prod.yml pull
             docker compose -f docker-compose.prod.yml up -d --force-recreate

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -3,10 +3,49 @@ services:
     image: djoufson/dotnetcameroon
     restart: unless-stopped
     container_name: dotnetcameroon
+    depends_on:
+      dotnetcameroon.sqlserver:
+        condition: service_healthy
+      dotnetcameroon.minio:
+        condition: service_healthy
     environment:
-      OTEL_EXPORTER_OTLP_ENDPOINT: http://localhost:18889
+      ASPNETCORE_ENVIRONMENT: Production
+      ASPNETCORE_URLS: http://+:8080
+
+      # --- Connection strings (nested config via __ separator) ---
+      ConnectionStrings__SqlServer: "${AZURE_SQLSERVER_WEBSITE_DATABASE}"
+      ConnectionStrings__Npgsql: "${AZURE_POSTGRES_WEBSITE_DATABASE}"
+      ConnectionStrings__Sqlite: "${SQLITE_CONNECTION:-Data Source=/app/data/projects.db;}"
+      ConnectionStrings__HangfireSqlite: "Data Source=/app/data/hangfire.db;"
+
+      # --- Cookie auth ---
+      CookiesOptions__Issuer: "${COOKIES_ISSUER}"
+      CookiesOptions__LoginPath: "${COOKIES_LOGINPATH:-/login}"
+      CookiesOptions__LogoutPath: "${COOKIES_LOGOUTPATH:-/logout}"
+      CookiesOptions__AccessDeniedPath: "${COOKIES_ACCESSDENIEDPATH:-/access-denied}"
+      CookiesOptions__ExpirationInDays: "${COOKIES_EXPIRATIONINDAYS:-30}"
+
+      # --- JWT (external API auth) ---
+      JwtOptions__Issuer: "${JWT_ISSUER:-DotnetCameroon}"
+      JwtOptions__Audience: "${JWT_AUDIENCE:-DotnetCameroon}"
+      JwtOptions__Secret: "${JWT_SECRET}"
+      JwtOptions__ExpirationInMinutes: "${JWT_EXPIRATION_IN_MINUTES:-60}"
+
+      # --- MinIO (object storage) ---
+      Minio__Endpoint: "${MINIO_ENDPOINT:-minio:9000}"
+      Minio__PublicEndpoint: "${MINIO_PUBLICENDPOINT}"
+      Minio__AccessKey: "${MINIO_ACCESSKEY}"
+      Minio__SecretKey: "${MINIO_SECRETKEY}"
+      Minio__BucketName: "${MINIO_BUCKETNAME:-uploads}"
+      Minio__UseSsl: "false"
+
+      # --- Observability ---
+      ApplicationInsights__InstrumentationKey: "${AZURE_APPINSIGHTS_INSTRUMENTAL_KEY}"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "${OTEL_EXPORTER_OTLP_ENDPOINT:-http://localhost:18889}"
     ports:
       - "${APP_PORT:-5000}:8080"
+    volumes:
+      - app-data:/app/data
   dotnetcameroon.sqlserver:
     image: mcr.microsoft.com/mssql/server:2022-latest
     container_name: dotnetcameroon.sqlserver
@@ -20,9 +59,19 @@ services:
       - "${MSSQL_PORT:-1433}:1433"
     volumes:
       - sqlserver-data:/var/opt/mssql
+    healthcheck:
+      test: [
+        "CMD-SHELL",
+        "/opt/mssql-tools18/bin/sqlcmd -S localhost -U SA -P \"$$MSSQL_SA_PASSWORD\" -Q 'SELECT 1' -C || exit 1"
+      ]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
   dotnetcameroon.minio:
     image: minio/minio:latest
     container_name: dotnetcameroon.minio
+    hostname: minio
     environment:
       MINIO_ROOT_USER: "${MINIO_ROOT_USER}"
       MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD}"
@@ -41,3 +90,4 @@ services:
 volumes:
   sqlserver-data:
   minio-data:
+  app-data:


### PR DESCRIPTION
## Summary
- Drop the build-time `microsoft/variable-substitution@v1` step that rewrote `appsettings.Production.json` with secrets. The Docker image is now identical across environments and contains no secrets.
- `docker-compose.prod.yml` now passes runtime config to the .NET app via `Section__Key` env vars (`ConnectionStrings__SqlServer`, `JwtOptions__Secret`, `Minio__*`, etc.), resolved from the existing GitHub Secret names so nothing needs renaming.
- The deploy workflow forwards all required secrets to the VPS via SSH, writes them to `.env`, then runs `docker compose up -d --force-recreate`. Secret rotation is now a restart, not an image rebuild.
- Non-sensitive operational values (ports, MSSQL_PID, MinIO endpoint, cookie paths, JWT issuer/audience/expiration, bucket name) have `${VAR:-default}` fallbacks in compose so they don't have to live in GitHub Secrets at all.
- Added healthchecks + `depends_on: service_healthy` for SQL Server and MinIO, and an `app-data` named volume for the SQLite databases.
- `.env.example` rewritten to mirror exactly what the workflow writes on the VPS, so a local prod-like setup is one-to-one with production.

## Action required before this merges to main
The previous workflow only handled `appsettings.*.json` substitution — container-init values (SA password, MinIO root creds) were presumably set by hand in a `.env` on the VPS. Three new GitHub Secrets must be created in repo settings before the next deploy run:

- `MSSQL_SA_PASSWORD`
- `MINIO_ROOT_USER`
- `MINIO_ROOT_PASSWORD`

## Test plan
- [ ] Create the three new GitHub Secrets above
- [ ] Verify `docker compose -f docker-compose.prod.yml --env-file .env.example config` parses locally with every `Section__Key` resolved (no `${...}` left)
- [ ] Trigger a deploy from `main`; verify the workflow no longer mutates `appsettings.Production.json`
- [ ] On the VPS, verify `.env` is written with `chmod 600` permissions and contains all expected keys
- [ ] Verify the running app container picks up the env vars (e.g. `docker exec dotnetcameroon env | grep -E 'ConnectionStrings__|JwtOptions__|Minio__'`)
- [ ] Smoke-test https://dotnet.cm: home page renders, admin login works, MinIO uploads work
- [ ] Rotate `JWT_SECRET` in GitHub Secrets and re-run the workflow; verify the new value is picked up without rebuilding the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)